### PR TITLE
Add minimum version option for Dicoogle 3.1.0

### DIFF
--- a/__tests__/generate-1.js
+++ b/__tests__/generate-1.js
@@ -14,7 +14,7 @@ describe('generator test 1: menu webplugin project in TypeScript', () => {
                 description: "A test plugin (#1)",
                 slotId: "menu",
                 caption: "Test1",
-                minimumVersion: "2.5.0",
+                minimumVersion: "3.1.0",
                 projectType: "typescript",
                 license: "MIT",
                 authorName: "John Doe",
@@ -45,6 +45,8 @@ describe('generator test 1: menu webplugin project in TypeScript', () => {
             },
             devDependencies: {
                 webpack: /.+/,
+                // only Dicoogle 3.1.0 uses dicoogle client v5
+                "dicoogle-client": /\^5/,
             }
         });
 

--- a/app/index.js
+++ b/app/index.js
@@ -85,12 +85,13 @@ module.exports = class WebpluginGenerator extends Generator {
         {
           type: 'list',
           name: 'minimumVersion',
-          message: 'Please specify the _minimum_ version of Dicoogle required for this plugin.',
+          message: 'Please specify the minimum version of Dicoogle required for this plugin.',
           choices: [
-            {name: '2.5.0 (exposes more features)', value: '2.5.0'},
-            {name: '2.4.0 (more compatible)', value: '2.4.0'}
+            {name: '3.1.0', value: '3.1.0'},
+            {name: '2.5.0 (legacy)', value: '2.5.0'},
+            {name: '2.4.0 (legacy, more compatible)', value: '2.4.0'}
           ],
-          default: '2.5.0'
+          default: '3.1.0'
         },
         {
           type: 'list',
@@ -209,6 +210,7 @@ module.exports = class WebpluginGenerator extends Generator {
       description,
       license,
       author,
+      minimumVersion,
       dicoogle,
     } = this.data;
 
@@ -263,7 +265,8 @@ module.exports = class WebpluginGenerator extends Generator {
       pkg.devDependencies[name] = req;
     }
     if (this.projectType === 'typescript') {
-      pkg.devDependencies['dicoogle-client'] = "^4.1.1";
+      let dicoogleClientVersion = semver.gte(minimumVersion, '3.1.0') ? '5.1.0' : '^4.1.1';
+      pkg.devDependencies['dicoogle-client'] = dicoogleClientVersion;
       if (this.componentType === 'react') {
         pkg.devDependencies['@types/react'] = "^0.14.0";
         pkg.devDependencies['@types/react-dom'] = "^0.14.0";


### PR DESCRIPTION
- affects version of dicoogle-client
- make "3.1.0" the default
- update test case 1 to create project with this minimum version
